### PR TITLE
Fix checkstyle issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ The library adheres to the interfaces in the [Interledger Protocol Core](https:/
 
 ## TODO
 
-    [ ] Fix Checkstyle issues
-    
+    [X] Fix Checkstyle issues
+    [ ] Update according to changes in dependencies
 
-	## Contributors
+## Contributors
 
-Any contribution is very much appreciated! [![gitter][gitter-image]][gitter-url]
+Any contribution is very much appreciated!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The library adheres to the interfaces in the [Interledger Protocol Core](https:/
 
 ## Contributors
 
+[![Join the chat on gitter][gitter-image]][gitter-url]
+
+[gitter-url]: https://gitter.im/interledger/java
+[gitter-image]: https://badges.gitter.im/interledger/java.svg
+
 Any contribution is very much appreciated!
 
 ## License

--- a/src/main/java/org/interledger/spsp/client/SpringSpspSenderService.java
+++ b/src/main/java/org/interledger/spsp/client/SpringSpspSenderService.java
@@ -1,9 +1,5 @@
 package org.interledger.spsp.client;
 
-import java.util.Objects;
-
-import javax.money.MonetaryAmount;
-
 import org.interledger.ilp.InterledgerPaymentRequest;
 import org.interledger.ilp.ledger.money.format.LedgerSpecificDecimalMonetaryAmountFormat;
 import org.interledger.setup.SetupService;
@@ -19,8 +15,12 @@ import org.interledger.spsp.json.model.JsonRequest;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Objects;
+import javax.money.MonetaryAmount;
+
 /**
- * An implementation of a Simple Payment Setup Protocol sender client service using a Spring rest template. 
+ * An implementation of a Simple Payment Setup Protocol sender client service
+ * using a Spring rest template.
  */
 public class SpringSpspSenderService implements SetupService {
 
@@ -37,7 +37,7 @@ public class SpringSpspSenderService implements SetupService {
   @Override
   public SpspReceiver query(ReceiverQuery query) {
     
-    if(!(query instanceof SpspReceiverQuery)){
+    if (!(query instanceof SpspReceiverQuery)) {
       throw new IllegalArgumentException("Only SPSP receiver queries are allowed.");
     }
     
@@ -45,14 +45,18 @@ public class SpringSpspSenderService implements SetupService {
     
     Objects.requireNonNull(spspQuery.getReceiverEndpoint());
     
-    JsonReceiver jsonReceiver = restTemplate.getForObject(spspQuery.getReceiverEndpoint(), JsonReceiver.class);
+    JsonReceiver jsonReceiver = restTemplate.getForObject(spspQuery.getReceiverEndpoint(),
+            JsonReceiver.class);
     return SpspJsonConverter.convertJsonReceiver(spspQuery.getReceiverEndpoint(), jsonReceiver);
   }
 
   @Override
-  public InterledgerPaymentRequest setupPayment(Receiver receiver, MonetaryAmount amount, String senderIdentifier, String memo) {
+  public InterledgerPaymentRequest setupPayment(Receiver receiver,
+                                                MonetaryAmount amount,
+                                                String senderIdentifier,
+                                                String memo) {
     
-    if(!(receiver instanceof SpspReceiver)) {
+    if (!(receiver instanceof SpspReceiver)) {
       throw new IllegalArgumentException("Only SPSP receivers are allowed.");
     }
     
@@ -62,21 +66,26 @@ public class SpringSpspSenderService implements SetupService {
     Objects.requireNonNull(amount);
     Objects.requireNonNull(senderIdentifier);
     
-    if(spspReceiver instanceof Invoice){
-      if(!((Invoice) spspReceiver).getAmount().equals(amount)) {
-        throw new IllegalArgumentException("The requested amount must match the amount on the Invoice.");
+    if (spspReceiver instanceof Invoice) {
+      if (!((Invoice) spspReceiver).getAmount().equals(amount)) {
+        throw new IllegalArgumentException("The requested amount must match the amount "
+                + "on the Invoice.");
       }
     }
 
     LedgerSpecificDecimalMonetaryAmountFormat formatter = 
-        new LedgerSpecificDecimalMonetaryAmountFormat(spspReceiver.getCurrencyUnit(), spspReceiver.getPrecision(), spspReceiver.getScale());
+        new LedgerSpecificDecimalMonetaryAmountFormat(spspReceiver.getCurrencyUnit(),
+                spspReceiver.getPrecision(),
+                spspReceiver.getScale());
     
     JsonRequest req = new JsonRequest();
     req.setAmount(formatter.format(amount));
     req.setSenderIdentifier(senderIdentifier);
     req.setMemo(memo);
 
-    JsonInterledgerPaymentRequest jsonIpr = restTemplate.postForObject(spspReceiver.getEndpoint(), req, JsonInterledgerPaymentRequest.class);
+    JsonInterledgerPaymentRequest jsonIpr = restTemplate.postForObject(spspReceiver.getEndpoint(),
+            req,
+            JsonInterledgerPaymentRequest.class);
     return SpspJsonConverter.convertJsonInterledgerPaymentRequest(spspReceiver, jsonIpr);
     
   }

--- a/src/main/java/org/interledger/spsp/client/model/ClientInvoice.java
+++ b/src/main/java/org/interledger/spsp/client/model/ClientInvoice.java
@@ -1,11 +1,10 @@
 package org.interledger.spsp.client.model;
 
-import java.net.URI;
-
-import javax.money.MonetaryAmount;
-
 import org.interledger.setup.spsp.model.Invoice;
 import org.interledger.setup.spsp.model.InvoiceStatus;
+
+import java.net.URI;
+import javax.money.MonetaryAmount;
 
 public class ClientInvoice extends ClientReceiver implements Invoice {
 

--- a/src/main/java/org/interledger/spsp/client/model/ClientPayee.java
+++ b/src/main/java/org/interledger/spsp/client/model/ClientPayee.java
@@ -1,8 +1,8 @@
 package org.interledger.spsp.client.model;
 
-import java.net.URI;
-
 import org.interledger.setup.spsp.model.Payee;
+
+import java.net.URI;
 
 public class ClientPayee extends ClientReceiver implements Payee {
 

--- a/src/main/java/org/interledger/spsp/client/model/ClientReceiver.java
+++ b/src/main/java/org/interledger/spsp/client/model/ClientReceiver.java
@@ -1,12 +1,11 @@
 package org.interledger.spsp.client.model;
 
-import java.net.URI;
-
-import javax.money.CurrencyUnit;
-
 import org.interledger.ilp.InterledgerAddress;
 import org.interledger.setup.spsp.model.ReceiverType;
 import org.interledger.setup.spsp.model.SpspReceiver;
+
+import java.net.URI;
+import javax.money.CurrencyUnit;
 
 public abstract class ClientReceiver implements SpspReceiver {
 
@@ -46,6 +45,7 @@ public abstract class ClientReceiver implements SpspReceiver {
   public int getScale() {
     return scale;
   }
+
   public void setEndpoint(URI endpoint) {
     this.endpoint = endpoint;
   }

--- a/src/main/java/org/interledger/spsp/json/ConditionDeserializer.java
+++ b/src/main/java/org/interledger/spsp/json/ConditionDeserializer.java
@@ -30,7 +30,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
       URI conditionUri = URI.create(parser.getValueAsString());
       
       //FIXME Temporary fix for old URI format
-      if("cc".equals(conditionUri.getScheme())) {
+      if ("cc".equals(conditionUri.getScheme())) {
         return getConditionFromOldUri(conditionUri);
       }
       
@@ -44,7 +44,7 @@ public class ConditionDeserializer extends StdDeserializer<Condition> {
     
     String[] parts = uri.toString().split(":");
     
-    if(!"0".equals(parts[1])) {
+    if (!"0".equals(parts[1])) {
       throw new RuntimeException("Only PreimageSha256 conditions are supported in the old format.");
     }
     

--- a/src/main/java/org/interledger/spsp/json/ConditionSerializer.java
+++ b/src/main/java/org/interledger/spsp/json/ConditionSerializer.java
@@ -1,15 +1,14 @@
 package org.interledger.spsp.json;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.interledger.cryptoconditions.Condition;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Base64;
-
-import org.interledger.cryptoconditions.Condition;
-
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 @SuppressWarnings("serial")
 //TODO: maybe this should be in java-crypto-conditions for anyone to use?
@@ -30,7 +29,8 @@ public class ConditionSerializer extends StdSerializer<Condition> {
   
   private URI getOldConditionUri(Condition condition) {
     
-    String fingerprint = new String(Base64.getUrlEncoder().encode(condition.getFingerprint()), Charset.forName("UTF-8"));
+    String fingerprint = new String(Base64.getUrlEncoder().encode(condition.getFingerprint()),
+            Charset.forName("UTF-8"));
     String cost = Long.toUnsignedString(condition.getCost());
     return URI.create("cc:0:3:" + fingerprint + ":" + cost);
   }

--- a/src/main/java/org/interledger/spsp/json/SpspJsonConverter.java
+++ b/src/main/java/org/interledger/spsp/json/SpspJsonConverter.java
@@ -1,12 +1,10 @@
 package org.interledger.spsp.json;
 
-import java.net.URI;
-
-import javax.money.CurrencyUnit;
-import javax.money.Monetary;
-
 import org.interledger.ilp.InterledgerPaymentRequest;
 import org.interledger.ilp.ledger.money.format.LedgerSpecificDecimalMonetaryAmountFormat;
+import org.interledger.setup.model.Receiver;
+import org.interledger.setup.spsp.model.ReceiverType;
+import org.interledger.setup.spsp.model.SpspReceiver;
 import org.interledger.spsp.client.model.ClientInvoice;
 import org.interledger.spsp.client.model.ClientPayee;
 import org.interledger.spsp.client.model.ClientReceiver;
@@ -14,16 +12,26 @@ import org.interledger.spsp.json.model.JsonInterledgerPaymentRequest;
 import org.interledger.spsp.json.model.JsonInvoice;
 import org.interledger.spsp.json.model.JsonPayee;
 import org.interledger.spsp.json.model.JsonReceiver;
-import org.interledger.setup.model.Receiver;
-import org.interledger.setup.spsp.model.ReceiverType;
-import org.interledger.setup.spsp.model.SpspReceiver;
+
+import java.net.URI;
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
 
 public class SpspJsonConverter {
-  
-  public static InterledgerPaymentRequest convertJsonInterledgerPaymentRequest(Receiver receiver, JsonInterledgerPaymentRequest jsonIpr) {
+
+  /**
+   * Converts JSON interledger payment request to InterledgerPaymentRequest.
+   * @param receiver Receiver
+   * @param jsonIpr JSON interledger payment request
+   * @return ipr InterledgerPaymentRequest
+   */
+  public static InterledgerPaymentRequest convertJsonInterledgerPaymentRequest(Receiver receiver,
+                                                          JsonInterledgerPaymentRequest jsonIpr) {
 
     LedgerSpecificDecimalMonetaryAmountFormat formatter = 
-        new LedgerSpecificDecimalMonetaryAmountFormat(receiver.getCurrencyUnit(), receiver.getPrecision(), receiver.getScale());
+        new LedgerSpecificDecimalMonetaryAmountFormat(receiver.getCurrencyUnit(),
+                receiver.getPrecision(),
+                receiver.getScale());
     
     InterledgerPaymentRequest ipr = new InterledgerPaymentRequest();
     ipr.setAddress(jsonIpr.getAddress());
@@ -34,7 +42,13 @@ public class SpspJsonConverter {
     ipr.setAdditionalHeaders(jsonIpr.getAdditionalHeaders());
     return ipr;
   }
-  
+
+  /**
+   * Converts JSON receiver to SpspReceiver.
+   * @param receiverEndpoint Receiver endpoint
+   * @param jsonReceiver JSON receiver
+   * @return receiver SpspReceiver
+   */
   public static SpspReceiver convertJsonReceiver(URI receiverEndpoint, JsonReceiver jsonReceiver) {
     
     
@@ -43,7 +57,7 @@ public class SpspJsonConverter {
     CurrencyUnit currency = Monetary.getCurrency(jsonReceiver.getCurrencyCode());
     ClientReceiver receiver;
     
-    switch(type) {
+    switch (type) {
       case invoice:
         ClientInvoice invoice = new ClientInvoice();
         receiver = invoice;
@@ -51,7 +65,9 @@ public class SpspJsonConverter {
         invoice.setInvoiceInfo(jsonInvoice.getInvoiceInfo());
         invoice.setStatus(jsonInvoice.getStatus());
         LedgerSpecificDecimalMonetaryAmountFormat formatter = 
-            new LedgerSpecificDecimalMonetaryAmountFormat(currency, jsonInvoice.getPrecision(), jsonReceiver.getScale());
+            new LedgerSpecificDecimalMonetaryAmountFormat(currency,
+                    jsonInvoice.getPrecision(),
+                    jsonReceiver.getScale());
         invoice.setAmount(formatter.parse(jsonInvoice.getAmount()));
         break;
       case payee:
@@ -73,7 +89,7 @@ public class SpspJsonConverter {
     receiver.setScale(jsonReceiver.getScale());
     
     //TODO Temp fix for older APIs that don't return this info
-    if(receiver.getPrecision() == 0 && receiver.getScale() == 0){
+    if (receiver.getPrecision() == 0 && receiver.getScale() == 0) {
       receiver.setPrecision(10);
       receiver.setScale(2);
     }

--- a/src/main/java/org/interledger/spsp/json/model/JsonInterledgerPaymentRequest.java
+++ b/src/main/java/org/interledger/spsp/json/model/JsonInterledgerPaymentRequest.java
@@ -1,15 +1,14 @@
 package org.interledger.spsp.json.model;
 
-import java.time.ZonedDateTime;
-
-import org.interledger.cryptoconditions.Condition;
-import org.interledger.ilp.InterledgerAddress;
-import org.interledger.spsp.json.ConditionDeserializer;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.interledger.cryptoconditions.Condition;
+import org.interledger.ilp.InterledgerAddress;
+import org.interledger.spsp.json.ConditionDeserializer;
+
+import java.time.ZonedDateTime;
 
 public class JsonInterledgerPaymentRequest {
 

--- a/src/main/java/org/interledger/spsp/json/model/JsonInvoice.java
+++ b/src/main/java/org/interledger/spsp/json/model/JsonInvoice.java
@@ -1,10 +1,9 @@
 package org.interledger.spsp.json.model;
 
-import java.net.URI;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.interledger.setup.spsp.model.InvoiceStatus;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
 
 public class JsonInvoice extends JsonReceiver {
 

--- a/src/main/java/org/interledger/spsp/json/model/JsonPayee.java
+++ b/src/main/java/org/interledger/spsp/json/model/JsonPayee.java
@@ -1,10 +1,10 @@
 package org.interledger.spsp.json.model;
 
-import java.net.URI;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class JsonPayee extends JsonReceiver{
+import java.net.URI;
+
+public class JsonPayee extends JsonReceiver {
 
   private String name;
   private URI imageUrl;

--- a/src/main/java/org/interledger/spsp/json/model/JsonReceiver.java
+++ b/src/main/java/org/interledger/spsp/json/model/JsonReceiver.java
@@ -1,9 +1,5 @@
 package org.interledger.spsp.json.model;
 
-import org.interledger.ilp.InterledgerAddress;
-import org.interledger.spsp.json.InterledgerAddressSerializer;
-import org.interledger.setup.spsp.model.ReceiverType;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -16,6 +12,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.interledger.ilp.InterledgerAddress;
+import org.interledger.setup.spsp.model.ReceiverType;
+import org.interledger.spsp.json.InterledgerAddressSerializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(content = Include.NON_NULL)

--- a/src/test/java/org/interledger/spsp/client/Application.java
+++ b/src/test/java/org/interledger/spsp/client/Application.java
@@ -45,11 +45,13 @@ public class Application {
       Receiver alice = service.query(new SpspReceiverQuery("https://red.ilpdemo.org/api/receivers/alice"));
       log.info("asked for receiver alice, got {}", alice);
       
-//      InterledgerPaymentRequest bobPayReq = service.setupPayment(bob, "10.40", "test@ipldemo.org", "totally fake for testing");
-//      log.info("asked bob to set up a payment, got {}", bobPayReq);
-//  
-//      InterledgerPaymentRequest alicePayReq = service.setupPayment(alice, "10.40", "test@ipldemo.org", "totally fake for testing");
-//      log.info("asked alice to set up a payment, got {}", alicePayReq);
+      //InterledgerPaymentRequest bobPayReq = service.setupPayment(bob, "10.40", "test@ipldemo.org",
+      // "totally fake for testing");
+      //log.info("asked bob to set up a payment, got {}", bobPayReq);
+      //
+      //InterledgerPaymentRequest alicePayReq = service.setupPayment(alice, "10.40",
+      // "test@ipldemo.org", "totally fake for testing");
+      //log.info("asked alice to set up a payment, got {}", alicePayReq);
     };
   }
 }

--- a/src/test/java/org/interledger/spsp/client/TestSpringSpspClientService.java
+++ b/src/test/java/org/interledger/spsp/client/TestSpringSpspClientService.java
@@ -8,35 +8,27 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.money.CurrencyQueryBuilder;
-import javax.money.CurrencyUnit;
-import javax.money.Monetary;
-import javax.money.MonetaryAmount;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.interledger.cryptoconditions.uri.CryptoConditionUri;
 import org.interledger.ilp.InterledgerAddress;
 import org.interledger.ilp.InterledgerPaymentRequest;
 import org.interledger.ilp.ledger.money.format.LedgerSpecificDecimalMonetaryAmountFormat;
+import org.interledger.setup.model.Receiver;
+import org.interledger.setup.spsp.model.Invoice;
+import org.interledger.setup.spsp.model.InvoiceStatus;
+import org.interledger.setup.spsp.model.Payee;
+import org.interledger.setup.spsp.model.ReceiverType;
+import org.interledger.setup.spsp.model.SpspReceiver;
+import org.interledger.setup.spsp.model.SpspReceiverQuery;
 import org.interledger.spsp.json.ConditionSerializer;
 import org.interledger.spsp.json.InterledgerAddressSerializer;
 import org.interledger.spsp.json.model.JsonInterledgerPaymentRequest;
 import org.interledger.spsp.json.model.JsonInvoice;
 import org.interledger.spsp.json.model.JsonPayee;
 import org.interledger.spsp.json.model.JsonRequest;
-import org.interledger.setup.spsp.model.Invoice;
-import org.interledger.setup.spsp.model.InvoiceStatus;
-import org.interledger.setup.spsp.model.Payee;
-import org.interledger.setup.model.Receiver;
-import org.interledger.setup.spsp.model.ReceiverType;
-import org.interledger.setup.spsp.model.SpspReceiver;
-import org.interledger.setup.spsp.model.SpspReceiverQuery;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
@@ -44,10 +36,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import javax.money.CurrencyQueryBuilder;
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+import javax.money.MonetaryAmount;
 
 public class TestSpringSpspClientService {
 
@@ -141,7 +139,8 @@ public class TestSpringSpspClientService {
     Invoice invoiceResponse = (Invoice) response;
     assertEquals(ReceiverType.invoice, invoiceResponse.getType());
     assertEquals(mockInvoice.getAccount(), invoiceResponse.getAccount());
-    assertEquals(mockInvoice.getCurrencyCode(), invoiceResponse.getCurrencyUnit().getCurrencyCode());
+    assertEquals(mockInvoice.getCurrencyCode(),
+            invoiceResponse.getCurrencyUnit().getCurrencyCode());
     assertEquals(mockInvoice.getAmount(), formatter.format(invoiceResponse.getAmount()));
     assertEquals(mockInvoice.getStatus(), invoiceResponse.getStatus());
     assertEquals(mockInvoice.getInvoiceInfo(), invoiceResponse.getInvoiceInfo());
@@ -210,10 +209,11 @@ public class TestSpringSpspClientService {
       }
     };
     
-    MonetaryAmount usdAmount = Monetary.getDefaultAmountFactory().setCurrency("USD").setNumber(10.40).create();
+    MonetaryAmount usdAmount = Monetary.getDefaultAmountFactory().setCurrency("USD")
+            .setNumber(10.40).create();
     
-    InterledgerPaymentRequest response = service.setupPayment(bobReceiver, usdAmount, "alice@blue.ilpdemo.org",
-        "Hey Bob!");
+    InterledgerPaymentRequest response = service.setupPayment(bobReceiver, usdAmount,
+            "alice@blue.ilpdemo.org", "Hey Bob!");
 
     assertNotNull(response);
     assertEquals(reqRsp.getAddress(), response.getAddress());


### PR DESCRIPTION
Hi guys! I fixed all the Checkstyle issues using the google_checks template. The most common issue is imports being out of order, for the Google Java style they should be like:
```
import static org.junit.Assert.assertEquals; // Static imports first
import static org.junit.Assert.assertNotNull;

import com.fasterxml.jackson.core.JsonProcessingException; // Then third party imports
import com.fasterxml.jackson.databind.ObjectMapper;

import java.net.MalformedURLException; // And finally, standard Java package imports
import java.net.URI;
```
Each import block should be separated by just one blank line.

I also modified the readme a bit :) let me know what you think 👍 